### PR TITLE
fix: Show proper icons for Synfig files

### DIFF
--- a/lib/morevna-studio/morevna-studio
+++ b/lib/morevna-studio/morevna-studio
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export MOREVNASTUDIO_VERSION=0.5
+export MOREVNASTUDIO_VERSION=0.6
 export USE_0INSTALL=0
 
 set -e

--- a/lib/morevna-studio/user-install
+++ b/lib/morevna-studio/user-install
@@ -44,10 +44,15 @@ install()
 	cp -f "${MOREVNASTUDIO_DIR}/share/mime/packages/$FILE" "$HOME/.local/share/mime/packages/"
     done
     
+    [ -d "$HOME/.local/share/mime-info/" ] || mkdir -p "$HOME/.local/share/mime-info/"
+    for FILE in `ls -1 "${MOREVNASTUDIO_DIR}/share/mime-info"`; do
+    	cp -f "${MOREVNASTUDIO_DIR}/share/mime-info/$FILE" "$HOME/.local/share/mime-info/"
+    done
+    
     update-desktop-database $HOME/.local/share/applications
+    update-mime-database $HOME/.local/share/mime/ || true
     
     #kbuildsycoca5 || kbuildsycoca4 --noincremental || true
-    #update-mime-database $HOME/.local/share/mime/ || true
     
     echo "MOREVNASTUDIO_INSTALLED_VERSION=$MOREVNASTUDIO_VERSION" > $HOME/.config/morevna-studio/morevna-studio.version
     

--- a/share/mime-info/synfigstudio.keys
+++ b/share/mime-info/synfigstudio.keys
@@ -1,0 +1,10 @@
+image/sif:
+	open=synfigstudio %f
+	view=synfigstudio %f
+	icon-filename=sif_icon.png
+	description=SYNFIG Composition
+	default_action_type=application
+	short_list_application_ids_for_novice_user_level=synfigstudio
+	short_list_application_ids_for_intermediate_user_level=synfigstudio
+	short_list_application_ids_for_advanced_user_level=synfigstudio
+#    category=Images

--- a/share/mime-info/synfigstudio.mime
+++ b/share/mime-info/synfigstudio.mime
@@ -1,0 +1,4 @@
+# mime types for synfig studio
+
+image/sif
+	ext: sif SIF sifZ SIFZ sif.gz SIF.GZ SIF.gz


### PR DESCRIPTION
Now Synfig files have correct icons in file manager

![screenshot_001](https://user-images.githubusercontent.com/332868/180232796-f7f6238b-0e9b-4ace-97c6-57ae631726d3.png)
